### PR TITLE
don't declare LedMatrixOptions as packed, as it isn't packed in the C++ lib

### DIFF
--- a/src/c.rs
+++ b/src/c.rs
@@ -14,7 +14,7 @@ pub struct LedColor {
 
 type LedMatrixOptionsResult = Result<(), &'static str>;
 
-#[repr(C, packed)]
+#[repr(C)]
 pub struct LedMatrixOptions {
     hardware_mapping: *mut c_char,
     rows: c_int,


### PR DESCRIPTION
the `LedMatrixOptions` struct was declared as `packed`, but the C++ lib does not do this. This resulted in a memory layout mismatch, causing segfaults (#7)