### PR TITLE
Add support for embedded-graphics crate traits

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,15 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build
       run: cargo build --verbose
-  
+
+  stripped-build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Stripped Build
+      run: cargo build --verbose --no-default-features
+
   clippy:
     runs-on: ubuntu-latest
 
@@ -32,7 +40,7 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         args: --all-features
-  
+
   format:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.1.5"
 authors = [
     "Vincent Pasquier <vincentpasquier@posteo.net>",
     "Tyler Holmes <tyler@holmesengineering.com>",
+    "Broderick Carlin <broderick.carlin@gmail.com>",
 ]
 repository = "https://github.com/rust-rpi-led-matrix/rust-rpi-rgb-led-matrix"
 homepage = "https://docs.rs/rpi-led-matrix/"
@@ -13,12 +14,18 @@ license = "GPL-3.0"
 readme = "README.md"
 edition = "2018"
 
+[features]
+
+default = ["embeddedgraphics"]
+
+embeddedgraphics = ["embedded-graphics"]
+
 [build-dependencies]
 gcc = "0.3"
 
 [dependencies]
 libc = "0.2"
-embedded-graphics = "0.6.2"
+embedded-graphics = { version = "0.6.2", optional = true }
 
 [profile.release]
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ gcc = "0.3"
 
 [dependencies]
 libc = "0.2"
+embedded-graphics = "0.6.2"
 
 [profile.release]
 codegen-units = 1

--- a/src/c.rs
+++ b/src/c.rs
@@ -1,16 +1,10 @@
+use crate::led_color::LedColor;
 use libc::{c_char, c_int};
 use std::ffi::CString;
 
 pub enum LedMatrix {}
 pub enum LedCanvas {}
 pub enum LedFont {}
-
-#[derive(Clone, Copy)]
-pub struct LedColor {
-    pub red: u8,
-    pub green: u8,
-    pub blue: u8,
-}
 
 type LedMatrixOptionsResult = Result<(), &'static str>;
 

--- a/src/led_color.rs
+++ b/src/led_color.rs
@@ -1,13 +1,18 @@
 #[cfg(feature = "embeddedgraphics")]
 use embedded_graphics::pixelcolor::{
-    Bgr555, Bgr565, Bgr888, Gray2, Gray4, Gray8, GrayColor, Rgb555, Rgb565, Rgb888, RgbColor,
+    raw::RawU24, Bgr555, Bgr565, Bgr888, Gray2, Gray4, Gray8, GrayColor, PixelColor, Rgb555,
+    Rgb565, Rgb888, RgbColor,
 };
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq)]
 pub struct LedColor {
     pub red: u8,
     pub green: u8,
     pub blue: u8,
+}
+
+impl PixelColor for LedColor {
+    type Raw = RawU24;
 }
 
 #[cfg(feature = "embeddedgraphics")]

--- a/src/led_color.rs
+++ b/src/led_color.rs
@@ -11,6 +11,7 @@ pub struct LedColor {
     pub blue: u8,
 }
 
+#[cfg(feature = "embeddedgraphics")]
 impl PixelColor for LedColor {
     type Raw = RawU24;
 }

--- a/src/led_color.rs
+++ b/src/led_color.rs
@@ -1,0 +1,100 @@
+use embedded_graphics::pixelcolor::{
+    Bgr555, Bgr565, Bgr888, Gray2, Gray4, Gray8, GrayColor, Rgb555, Rgb565, Rgb888, RgbColor,
+};
+
+#[derive(Clone, Copy)]
+pub struct LedColor {
+    pub red: u8,
+    pub green: u8,
+    pub blue: u8,
+}
+
+impl From<Bgr555> for LedColor {
+    fn from(p: Bgr555) -> Self {
+        LedColor {
+            red: p.r() << 3,
+            green: p.g() << 3,
+            blue: p.b() << 3,
+        }
+    }
+}
+
+impl From<Bgr565> for LedColor {
+    fn from(p: Bgr565) -> Self {
+        LedColor {
+            red: p.r() << 3,
+            green: p.g() << 2,
+            blue: p.b() << 3,
+        }
+    }
+}
+
+impl From<Bgr888> for LedColor {
+    fn from(p: Bgr888) -> Self {
+        LedColor {
+            red: p.r(),
+            green: p.g(),
+            blue: p.b(),
+        }
+    }
+}
+
+impl From<Gray2> for LedColor {
+    fn from(p: Gray2) -> Self {
+        LedColor {
+            red: p.luma() << 6,
+            green: p.luma() << 6,
+            blue: p.luma() << 6,
+        }
+    }
+}
+
+impl From<Gray4> for LedColor {
+    fn from(p: Gray4) -> Self {
+        LedColor {
+            red: p.luma() << 4,
+            green: p.luma() << 4,
+            blue: p.luma() << 4,
+        }
+    }
+}
+
+impl From<Gray8> for LedColor {
+    fn from(p: Gray8) -> Self {
+        LedColor {
+            red: p.luma(),
+            green: p.luma(),
+            blue: p.luma(),
+        }
+    }
+}
+
+impl From<Rgb555> for LedColor {
+    fn from(p: Rgb555) -> Self {
+        LedColor {
+            red: p.r() << 3,
+            green: p.g() << 3,
+            blue: p.b() << 3,
+        }
+    }
+}
+
+impl From<Rgb565> for LedColor {
+    fn from(p: Rgb565) -> Self {
+        LedColor {
+            red: p.r() << 3,
+            green: p.g() << 2,
+            blue: p.b() << 3,
+        }
+    }
+}
+
+impl From<Rgb888> for LedColor {
+    fn from(p: Rgb888) -> Self {
+        LedColor {
+            red: p.r(),
+            green: p.g(),
+            blue: p.b(),
+        }
+    }
+}

--- a/src/led_color.rs
+++ b/src/led_color.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "embeddedgraphics")]
 use embedded_graphics::pixelcolor::{
     Bgr555, Bgr565, Bgr888, Gray2, Gray4, Gray8, GrayColor, Rgb555, Rgb565, Rgb888, RgbColor,
 };
@@ -9,6 +10,7 @@ pub struct LedColor {
     pub blue: u8,
 }
 
+#[cfg(feature = "embeddedgraphics")]
 impl From<Bgr555> for LedColor {
     fn from(p: Bgr555) -> Self {
         LedColor {
@@ -19,6 +21,7 @@ impl From<Bgr555> for LedColor {
     }
 }
 
+#[cfg(feature = "embeddedgraphics")]
 impl From<Bgr565> for LedColor {
     fn from(p: Bgr565) -> Self {
         LedColor {
@@ -29,6 +32,7 @@ impl From<Bgr565> for LedColor {
     }
 }
 
+#[cfg(feature = "embeddedgraphics")]
 impl From<Bgr888> for LedColor {
     fn from(p: Bgr888) -> Self {
         LedColor {
@@ -39,6 +43,7 @@ impl From<Bgr888> for LedColor {
     }
 }
 
+#[cfg(feature = "embeddedgraphics")]
 impl From<Gray2> for LedColor {
     fn from(p: Gray2) -> Self {
         LedColor {
@@ -49,6 +54,7 @@ impl From<Gray2> for LedColor {
     }
 }
 
+#[cfg(feature = "embeddedgraphics")]
 impl From<Gray4> for LedColor {
     fn from(p: Gray4) -> Self {
         LedColor {
@@ -59,6 +65,7 @@ impl From<Gray4> for LedColor {
     }
 }
 
+#[cfg(feature = "embeddedgraphics")]
 impl From<Gray8> for LedColor {
     fn from(p: Gray8) -> Self {
         LedColor {
@@ -69,6 +76,7 @@ impl From<Gray8> for LedColor {
     }
 }
 
+#[cfg(feature = "embeddedgraphics")]
 impl From<Rgb555> for LedColor {
     fn from(p: Rgb555) -> Self {
         LedColor {
@@ -79,6 +87,7 @@ impl From<Rgb555> for LedColor {
     }
 }
 
+#[cfg(feature = "embeddedgraphics")]
 impl From<Rgb565> for LedColor {
     fn from(p: Rgb565) -> Self {
         LedColor {
@@ -89,6 +98,7 @@ impl From<Rgb565> for LedColor {
     }
 }
 
+#[cfg(feature = "embeddedgraphics")]
 impl From<Rgb888> for LedColor {
     fn from(p: Rgb888) -> Self {
         LedColor {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,15 @@
 extern crate libc;
 mod c;
+mod led_color;
 
+use embedded_graphics::{drawable::Pixel, geometry::Size, pixelcolor::PixelColor, DrawTarget};
 use libc::{c_char, c_int};
 use std::ffi::CString;
 use std::path::Path;
 use std::ptr::null;
 
-pub use c::LedColor;
 pub use c::LedMatrixOptions;
+pub use led_color::LedColor;
 
 pub struct LedCanvas {
     handle: *mut c::LedCanvas,
@@ -207,6 +209,29 @@ impl LedCanvas {
                 ) as i32
             }
         }
+    }
+}
+
+impl<C> DrawTarget<C> for LedCanvas
+where
+    C: Into<LedColor> + PixelColor,
+{
+    type Error = core::convert::Infallible;
+
+    fn draw_pixel(&mut self, item: Pixel<C>) -> Result<(), Self::Error> {
+        let Pixel(point, color) = item;
+        self.set(point.x, point.y, &color.into());
+        Ok(())
+    }
+
+    fn size(&self) -> Size {
+        let size = self.size();
+        Size::new(size.0 as u32, size.1 as u32)
+    }
+
+    fn clear(&mut self, color: C) -> Result<(), Self::Error> {
+        self.fill(&color.into());
+        Ok(())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ extern crate libc;
 mod c;
 mod led_color;
 
+#[cfg(feature = "embeddedgraphics")]
 use embedded_graphics::{drawable::Pixel, geometry::Size, pixelcolor::PixelColor, DrawTarget};
 use libc::{c_char, c_int};
 use std::ffi::CString;
@@ -212,6 +213,7 @@ impl LedCanvas {
     }
 }
 
+#[cfg(feature = "embeddedgraphics")]
 impl<C> DrawTarget<C> for LedCanvas
 where
     C: Into<LedColor> + PixelColor,


### PR DESCRIPTION
Adding support for the embedded-graphics `DrawTarget` trait generic over any type `C` that impl's `Into<LedColor>`. All of the pixelcolor variants provided through embedded-graphics are supported also through this PR. An alternative implementation for `clear()` is also provided that takes advantage of the `fill()` method exposed.  Alternative implementations for the other provided functions to take advantage of the hardware acceleration are non-trivial and left as an exercise for a future PR (should probably create a ticket to track this)