### PR TITLE
use new C++ API to utilize RT options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # Control RGB LED displays from Rust
 
-This repository contains rust bindings for [rpi-rgb-led-matrix](https://github.com/hzeller/rpi-rgb-led-matrix)
+This repository contains rust bindings for [rpi-rgb-led-matrix](https://github.com/hzeller/rpi-rgb-led-matrix).
+In order to take advantage of the newer APIs, the minimum supported commit of the library is
+[55fa32f](https://github.com/hzeller/rpi-rgb-led-matrix/commit/55fa32fc2e02afb254ac834aea93589d5b891a11)
+(Sept. 7th, 2020), which exposes all parameters that affect how the matrix runs.

--- a/src/c.rs
+++ b/src/c.rs
@@ -31,6 +31,14 @@ pub struct LedMatrixOptions {
     limit_refresh_rate_hz: c_int,
 }
 
+#[repr(C)]
+pub struct LedRuntimeOptions {
+    gpio_slowdown: c_int,
+    daemon: c_int,
+    drop_privileges: c_int,
+    do_gpio_init: bool,
+}
+
 impl LedMatrixOptions {
     pub fn new() -> LedMatrixOptions {
         LedMatrixOptions {
@@ -167,6 +175,39 @@ impl Drop for LedMatrixOptions {
     }
 }
 
+impl LedRuntimeOptions {
+    pub fn new() -> Self {
+        Self {
+            gpio_slowdown: 1,
+            daemon: 0,
+            drop_privileges: 1,
+            do_gpio_init: true,
+        }
+    }
+
+    pub fn set_gpio_slowdown(&mut self, gpio_slowdown: i32) {
+        self.gpio_slowdown = gpio_slowdown;
+    }
+
+    pub fn set_daemon(&mut self, daemon: i32) {
+        self.daemon = daemon;
+    }
+
+    pub fn set_drop_privileges(&mut self, drop_privileges: i32) {
+        self.drop_privileges = drop_privileges;
+    }
+
+    pub fn set_do_gpio_init(&mut self, do_gpio_init: bool) {
+        self.do_gpio_init = do_gpio_init;
+    }
+}
+
+impl Default for LedRuntimeOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[allow(dead_code)]
 impl LedCanvas {
     pub fn size(&self) -> (i32, i32) {
@@ -275,10 +316,14 @@ impl LedCanvas {
 
 #[link(name = "rgbmatrix")]
 extern "C" {
-    pub fn led_matrix_create_from_options(
-        options: *const LedMatrixOptions,
-        argc: *mut c_int,
-        argv: *mut *mut *mut c_char,
+    // pub fn led_matrix_create_from_options(
+    //     options: *const LedMatrixOptions,
+    //     argc: *mut c_int,
+    //     argv: *mut *mut *mut c_char,
+    // ) -> *mut LedMatrix;
+    pub fn led_matrix_create_from_options_and_rt_options(
+        opts: *mut LedMatrixOptions,
+        rt_opts: *mut LedRuntimeOptions
     ) -> *mut LedMatrix;
     //    pub fn led_matrix_create(
     //        rows: c_int, chained: c_int, parallel: c_int) -> *mut LedMatrix;

--- a/src/c.rs
+++ b/src/c.rs
@@ -316,19 +316,12 @@ impl LedCanvas {
 
 #[link(name = "rgbmatrix")]
 extern "C" {
-    // pub fn led_matrix_create_from_options(
-    //     options: *const LedMatrixOptions,
-    //     argc: *mut c_int,
-    //     argv: *mut *mut *mut c_char,
-    // ) -> *mut LedMatrix;
+    // unused C functions omitted
     pub fn led_matrix_create_from_options_and_rt_options(
         opts: *mut LedMatrixOptions,
         rt_opts: *mut LedRuntimeOptions,
     ) -> *mut LedMatrix;
-    //    pub fn led_matrix_create(
-    //        rows: c_int, chained: c_int, parallel: c_int) -> *mut LedMatrix;
     pub fn led_matrix_delete(matrix: *mut LedMatrix);
-    //    pub fn led_matrix_print_flags(out: *mut FILE);
     pub fn led_matrix_get_canvas(matrix: *mut LedMatrix) -> *mut LedCanvas;
     pub fn led_canvas_get_size(canvas: *const LedCanvas, width: *mut c_int, height: *mut c_int);
     pub fn led_canvas_set_pixel(canvas: *mut LedCanvas, x: c_int, y: c_int, r: u8, g: u8, b: u8);

--- a/src/c.rs
+++ b/src/c.rs
@@ -323,7 +323,7 @@ extern "C" {
     // ) -> *mut LedMatrix;
     pub fn led_matrix_create_from_options_and_rt_options(
         opts: *mut LedMatrixOptions,
-        rt_opts: *mut LedRuntimeOptions
+        rt_opts: *mut LedRuntimeOptions,
     ) -> *mut LedMatrix;
     //    pub fn led_matrix_create(
     //        rows: c_int, chained: c_int, parallel: c_int) -> *mut LedMatrix;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,20 +29,8 @@ impl LedMatrix {
         options: Option<LedMatrixOptions>,
         rt_options: Option<LedRuntimeOptions>,
     ) -> Result<LedMatrix, &'static str> {
-        let mut options = {
-            if let Some(o) = options {
-                o
-            } else {
-                LedMatrixOptions::new()
-            }
-        };
-        let mut rt_options = {
-            if let Some(o) = rt_options {
-                o
-            } else {
-                LedRuntimeOptions::new()
-            }
-        };
+        let mut options = options.unwrap_or_default();
+        let mut rt_options = rt_options.unwrap_or_default();
 
         let handle = unsafe {
             c::led_matrix_create_from_options_and_rt_options(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,8 +25,10 @@ pub struct LedFont {
 }
 
 impl LedMatrix {
-    pub fn new(options: Option<LedMatrixOptions>, rt_options: Option<LedRuntimeOptions>)
-            -> Result<LedMatrix, &'static str> {
+    pub fn new(
+        options: Option<LedMatrixOptions>,
+        rt_options: Option<LedRuntimeOptions>,
+    ) -> Result<LedMatrix, &'static str> {
         let mut options = {
             if let Some(o) = options {
                 o


### PR DESCRIPTION
Take advantage of the new C++ API to modify runtime options, like `gpio_slowdown`. Enabled on the C++ side by [this PR](https://github.com/hzeller/rpi-rgb-led-matrix/pull/1141)