### PR TITLE
Implement Send + Sync for LedCanvas

### DIFF
--- a/rpi-led-matrix/CHANGELOG.md
+++ b/rpi-led-matrix/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Link to pure rust rewrite of `rpi-led-matrix`
 - dependabot updates of CI only crates
 - Update `embedded-graphics-core` to `0.4` and `embedded-graphics` to `0.8`
+- Implement Send + Sync for LedCanvas
 
 ## [0.4.0] - 2022-01-05
 

--- a/rpi-led-matrix/src/canvas.rs
+++ b/rpi-led-matrix/src/canvas.rs
@@ -16,6 +16,16 @@ pub struct LedCanvas {
     pub(crate) handle: *mut ffi::CLedCanvas,
 }
 
+/// Implements both the [`Send`] and [`Sync`] traits for [`LedCanvas`].
+///
+/// The underlying handle referenced by this FFI is [heap-allocated],
+/// allowing safe ownership transfer between threads. Additionally,
+/// references to this handle can be safely shared across thread boundaries.
+///
+/// [heap-allocated]: https://github.com/hzeller/rpi-rgb-led-matrix/blob/0ff6a6973f95d14e3206bcef1201237097fa8edd/lib/led-matrix.cc#L501
+unsafe impl Send for LedCanvas {}
+unsafe impl Sync for LedCanvas {}
+
 impl LedCanvas {
     /// Retrieves the width & height of the canvas
     #[must_use]


### PR DESCRIPTION


# Checklist

Thanks for contributing! Please ensure

- [x] All tests are passing
- [x] Tests or examples are added, if necessary
- [x] Add a `CHANGELOG.md` entryin the *Unreleased* section under the appropriate heading

# Pull Request Description

Since led_matrix_swap_on_vsync() will block until the next vsync, implementing the Send + Sync traits for LedCanvas will allow the canvas to be sent between a render thread and a draw thread. Since the underlying canvas is created with CreateFrameCanvas(), which allocates the canvas memory on the heap, it is safe to share between threads.
