### PR TITLE
Properly configure CC/CXX if we are cross compiling

### DIFF
--- a/rpi-led-matrix-sys/CHANGELOG.md
+++ b/rpi-led-matrix-sys/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## UNRELEASED
 
+- While cross-compiling, pass the correct CC and CXX to the Makefile.
+
 ## [0.2.1] - 2022-01-05
 
 - tweaked categories and reduced the size of the package by excluding unneeded parts of the c++ library.

--- a/rpi-led-matrix-sys/Cargo.toml
+++ b/rpi-led-matrix-sys/Cargo.toml
@@ -31,6 +31,7 @@ include = [
 libc = "0.2"
 
 [build-dependencies]
+cc = "1.2"
 copy_dir = "0.1"
 
 [features]

--- a/rpi-led-matrix-sys/build.rs
+++ b/rpi-led-matrix-sys/build.rs
@@ -63,7 +63,13 @@ fn main() {
         [cpp_lib_out_dir.to_str().unwrap(), "lib"].iter().collect();
     std::env::set_current_dir(&cpp_lib_lib_out_dir).unwrap();
     println!("building from {}", cpp_lib_out_dir.display());
+    let cc_path = cc::Build::new().get_compiler();
+    let cxx_path = cc::Build::new().cpp(true).get_compiler();
     let status = Command::new("make")
+        .args([
+            format!("CC={}", cc_path.path().to_str().unwrap()),
+            format!("CXX={}", cxx_path.path().to_str().unwrap()),
+        ])
         .status()
         .expect("process failed to execute");
     assert!(status.success(), "failed to compile the C++ library");


### PR DESCRIPTION
# Checklist

Thanks for contributing! Please ensure

- [x] All tests are passing
- [x] Tests or examples are added, if necessary
- [x] Add a `CHANGELOG.md` entryin the *Unreleased* section under the appropriate heading

# Pull Request Description

This PR fixes how `rpi-led-matrix-sys` package compiles its C/C++ dependency by specifying CC/CXX parameter using `cc` crate.

At least tested on aarch64-unknown-linux-gnu target. (`cross --target aarch64-unknown-linux-gnu`)

This fixes #43 